### PR TITLE
Add tests to aid in DCE connection debugging

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -18,3 +18,7 @@
 	color: rgb(0,0,0);
 	font-weight: 600;
 }
+
+.disclaimer {
+	font-size: small;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -2,10 +2,50 @@ import React, {PureComponent} from 'react';
 import './App.css';
 import Header from './Header';
 import TestItemList from "./TestItemList";
-import tests from './tests';
+import internalTests from './internalTests';
+import dceTests from './digitalCareerEventTests';
 import Environment from "./Environment";
 
 const Line = <p className="line"/>;
+
+function InternalTest() {
+	return (
+		<>
+			<TestItemList tests={internalTests}/>
+
+			<p>
+				<sup>*</sup>
+				In case the your network does not support IPv6 the IPv6 tests can fail.
+				This does not indicate a problem as long as the IPv4 tests succeed.
+			</p>
+		</>
+	);
+}
+
+function DigitalCareerEventTests() {
+	return (
+		<>
+			<TestItemList tests={dceTests}/>
+
+			<p>
+				<sup>*</sup>
+				The app will continue to function properly if these analytics services fail. Less data might be available though.
+				<br/>
+				<sup>**</sup>
+				These are overarching domains, and may fail without impacting the application.
+			</p>
+
+			<p className="disclaimer">
+				This application is only provided as a tool for debugging purposes. It does not in any way guarantee access to the application.
+				No rights can be derived from the data in this tool.
+			</p>
+		</>
+	);
+}
+
+function loadTests() {
+	return window.location.pathname === '/dce' ? <DigitalCareerEventTests/> : <InternalTest/>;
+}
 
 class App extends PureComponent {
 
@@ -14,17 +54,14 @@ class App extends PureComponent {
 			<div className="App">
 				<Header/>
 				<p className="App-intro">
-					This system will determine whether there are any connectivity issues between your computer and the Magnet.me
-					network.
+					This system will determine whether there are any connectivity issues between your computer and the Magnet.me network.
 				</p>
 				<p>
 					The test consists of two separate parts.
 				</p>
 				<ol>
 					<li>The first part will automatically perform several connectivity checks.</li>
-					<li>The second part includes information about the system you are using (no personal information will be
-						included).
-					</li>
+					<li>The second part includes information about the system you are using (no personal information will be included).</li>
 				</ol>
 
 				{Line}
@@ -35,13 +72,7 @@ class App extends PureComponent {
 
 				{Line}
 
-				<TestItemList tests={tests}/>
-
-				<p>
-					<sup>*</sup>
-					In case the your network does not support IPv6 the IPv6 tests can fail.
-					This does not indicate a problem as long as the IPv4 tests succeed.
-				</p>
+				{loadTests()}
 
 				{Line}
 

--- a/src/digitalCareerEventTests.js
+++ b/src/digitalCareerEventTests.js
@@ -1,0 +1,68 @@
+import {performNetworkRequest, pingTest} from "./tests";
+import {loadAsImage, loadAsScript} from "./loaders";
+
+function testOf(name, description, test) {
+	return {
+		name,
+		description,
+		test,
+	}
+}
+
+function margin() {
+	return {};
+}
+
+/**
+ * DCE uses the following domains (from https://hopin.zendesk.com/hc/en-gb/articles/360056528911-Network-Connectivity-Settings)
+ - hopin.to                                     App domain                                  X
+ - hopin.com                                    App domain                                  X
+ - tokbox.com                                   Video control domain                        X
+ - assets.hopin.to                              App domain                                  X
+ - app.hopin.com                                Hopin API                                   X
+ - src.litix.io                                 Tracking domain (no access required)        X
+ - player.live-video.net                        AWS video offloading                        X
+ - cdn.segment.com                              Tracking domain (no access required)        X
+ - opentok.com                                  WebRTC video domain                         X
+ - pusher.com                                   Tracking domain (no access required)        X
+ - herokuapp.com                                Seems unused                                (done implicitly above)
+ - mux.com                                      Seems unused                                X
+ - twilio.com                                   Seems unused                                X
+ - prod.live.hopin.to                           Hopin API                                   X
+ - hopin-analytics-production.herokuapp.com     Tracking domain (no access required)        X
+ - *.live-video.net                             AWS video offloading                        (done implicitly above)
+ - *.litix.io                                   Tracking domain (no access required)        (done implicitly above)
+ */
+const tests = [
+		margin(),
+
+		testOf('Ping', 'Can you contact Magnet.me at all (domain)?', pingTest('https://magnet.me')),
+		testOf('Ping Hopin.to', 'Can you contact our service provider?', pingTest('https://hopin.to')),
+		testOf('Ping Hopin.com', 'Can you contact our service provider?', pingTest('https://hopin.com')),
+		testOf('Ping CDN', 'Can you contact the CDN?', pingTest('https://assets.hopin.to')),
+		testOf('Ping App', 'Can you contact the app?', pingTest('https://app.hopin.com')),
+		testOf('Ping API', 'Can you contact the API?', pingTest('https://prod.live.hopin.to')),
+
+		margin(),
+		testOf('Ping Tokbox', 'Video control domain', pingTest('https://tokbox.com')),
+		testOf('Ping live-video.net', 'Video offloading domain', pingTest('https://player.live-video.net')),
+		testOf('Ping Opentok', 'WebRTC Video domain', pingTest('https://opentok.com')),
+
+		margin(),
+		testOf('Ping analytics1 *', '', pingTest('https://src.litix.io')),
+		testOf('Ping analytics2 *', '', pingTest('https://cdn.segment.com')),
+		testOf('Ping analytics3 *', '', pingTest('https://stats.pusher.com')),
+		testOf('Ping analytics4 *', '', pingTest('https://hopin-analytics-production.herokuapp.com')),
+
+		margin(),
+		testOf('Script analytics1 *', '', loadAsScript('https://src.litix.io/theoplayer/3/theoplayer-mux.js')),
+		testOf('Script analytics2 *', '', loadAsScript('https://cdn.segment.com/analytics.js/v1/MsAdSjf1InKNkevAlvPNpbmJLGQmt3D8/analytics.min.js')),
+		testOf('Script analytics3 *', '', loadAsImage('https://pusher.com/static/pusher-logo-c34a06c6aa0c11678c5f261d23bebb03.svg')),
+
+		margin(),
+		testOf('Ping mux **', '', pingTest('https://mux.com')),
+		testOf('Ping twilio **', '', pingTest('https://twilio.com')),
+	]
+;
+
+export default tests;

--- a/src/internalTests.js
+++ b/src/internalTests.js
@@ -1,0 +1,158 @@
+import {loadAsImage, loadAsScript, loadAsStyleSheet} from "./loaders";
+import {performNetworkRequest, pingTest} from "./tests";
+
+async function checkHttp2() {
+	const result = await performNetworkRequest(`https://clients.magnet.me/http_version`)();
+	try {
+		const text = await result.response.text();
+		return {
+			success : text === 'h2',
+			response : text,
+		}
+	} catch (e) {
+		return {
+			success : false,
+			response : e,
+		}
+	}
+}
+
+async function checkTlsProtocol() {
+	const result = await performNetworkRequest(`https://clients.magnet.me/ssl_protocol`)();
+	try {
+		const text = await result.response.text();
+		return {
+			success : text === 'TLSv1.3',
+			response : text,
+		}
+	} catch (e) {
+		return {
+			success : false,
+			response : e,
+		}
+	}
+}
+
+function websockets(secure = false) {
+	const message = `Magnet.me websocket test ${Math.random()}`;
+	return async () => new Promise(((resolve, reject) => {
+		const failed = () => reject({
+			success : false,
+		});
+		const timeout = setTimeout(() => {
+			console.warn('WSS took too long');
+			failed();
+		}, 5000);
+
+		try {
+			const websocket = new WebSocket(`${secure ? 'wss' : 'ws'}://echo.websocket.org/`);
+			let start;
+			websocket.onopen = () => {
+				start = new Date();
+				websocket.send(message);
+			};
+
+			websocket.onmessage = (evt) => {
+				const responseData = evt.data;
+				if (responseData === message) {
+					clearTimeout(timeout);
+					resolve({
+						success : true,
+						response : new Date() - start,
+					});
+				} else {
+					console.log(`Response data was '${responseData}', expected '${message}'.`);
+					failed();
+				}
+			};
+			websocket.onerror = () => {
+				clearTimeout(timeout);
+				failed();
+			}
+		} catch (e) {
+			console.warn(e);
+			clearTimeout(timeout);
+			failed();
+		}
+	}));
+}
+
+function testOf(name, description, test) {
+	return {
+		name,
+		description,
+		test,
+	}
+}
+
+function margin() {
+	return {};
+}
+
+const tests = [
+		margin(),
+
+		testOf('Ping', 'Can you contact Magnet.me at all (domain)?', pingTest('http://magnet.me')),
+		testOf('Ping LB', 'Can you contact our datacenter?', pingTest('http://loadbalancer.magnet.me')),
+		testOf('Ping CDN', 'Can you contact our CDN?', pingTest('http://cdn.magnet.me')),
+		testOf('Ping CDN2', 'Can you contact our alternate CDN?', pingTest('http://cdn2.magnet.me')),
+		testOf('Ping OAuth', 'Can you contact our authentication layer?', performNetworkRequest('https://oauth.magnet.me', 'no-cors')),
+		// No pings for Oauth, since it does not allow remote checks for security reasons
+		margin(),
+
+		testOf('IPv4 - no DNS', 'Does connecting over ipv4 without DNS work?', performNetworkRequest('http://136.144.129.63', 'no-cors')),
+		margin(),
+
+		testOf('IPv4 / HTTP', 'Does connecting over ipv4 work?', performNetworkRequest('http://clients-4.magnet.me')),
+		testOf('IPv4 / HTTPS', 'Does connecting over ipv4 with HTTPS work?', performNetworkRequest('https://clients-4.magnet.me')),
+		margin(),
+
+		// These are allowed to fail if the client network does not support ipv6
+		testOf('IPv6 / HTTP', 'Does connecting over ipv6 work? *', performNetworkRequest('http://clients-6.magnet.me')),
+		testOf('IPv6 / HTTPS', 'Does connecting over ipv6 with HTTPS work? *', performNetworkRequest('https://clients-6.magnet.me')),
+		margin(),
+
+		// The two tests below only work in production
+		testOf('HTTP', 'Can you communicate over HTTP?', loadAsScript(`http://${window.location.host}/demo.js`)),
+		testOf('HTTPS', 'Can you communicate over HTTPS?', loadAsScript(`https://${window.location.host}/demo.js`)),
+		testOf('Secure websockets', 'Can you communicate over secure websockets?', websockets(true)),
+		margin(),
+
+		testOf('Image', 'Can you reach our imaging subsystem?', performNetworkRequest(`https://customerimages.magnet.me/_health`)),
+		testOf('OAuth', 'Can you reach our authentication subsystem?', loadAsScript(`https://oauth.magnet.me/static/js/authentication.js`)),
+		margin(),
+
+		testOf('Web', 'Can you reach our web servers?', loadAsScript(`https://magnet.me/healthcheck`)),
+		testOf('API', 'Can you reach our APIs?', performNetworkRequest(`https://api.magnet.me/healthcheck`)),
+		testOf('Email', 'Can you reach our email servers?', performNetworkRequest(`https://email.magnet.me/_health`, 'no-cors')),
+		testOf('CDN', 'Can you reach our CDN servers?', performNetworkRequest(`https://cdn.magnet.me/images/logo-bigger.png`)),
+		testOf('Fonts', 'Can you load our fonts?', loadAsStyleSheet(`https://magnet.me/fonts/css?family=Source+Sans+Pro:300,400,400i,600,700&display=swap&subset=latin`)),
+		testOf('HTTP2', 'Can you communicate over HTTP2?', checkHttp2),
+		testOf('TLSv1.3', 'Can you communicate using TLSv1.3?', checkTlsProtocol),
+		testOf('Hubspot', 'Can you reach Hubspot?', loadAsScript('https://www.hubspot.com/hs/hsstatic/cos-i18n/static-1.16/bundles/project.js')),
+		testOf('Tentamenrooster', 'Can you reach Tentamenrooster.nl?', loadAsScript('https://tentamenrooster.nl')),
+		margin(),
+
+		// This checks whether Social stuff might be blocked
+		testOf('Facebook', 'Can you contact Facebook.com at all?', pingTest('https://facebook.com')),
+		testOf('LinkedIn', 'Can you contact LinkedIn.com at all?', pingTest('https://www.linkedin.com')),
+		testOf('Twitter', 'Can you contact Twitter.com at all?', pingTest('https://twitter.com')),
+		margin(),
+
+		// Or parts of our Google platform
+		testOf('Google SE', 'Can you contact google.com?', performNetworkRequest('https://www.google.com/', 'no-cors')),
+		testOf('Google Docs', 'Can you contact Google Docs?', performNetworkRequest('https://docs.google.com/forms/d/e/1FAIpQLSf-UqflUetJ64U_h1K8eGjePLArMeBknoaH_tkOZPqq9dizLg/viewform', 'no-cors')),
+		margin(),
+
+		// More internal test of social networks
+		testOf('Facebook CSS', 'Can you reach Facebook Network?', performNetworkRequest('https://facebook.com/security/hsts-pixel.gif')),
+		testOf('LinkedIn JS', 'Can you reach LinkedIn JS?', loadAsScript('https://platform.linkedin.com/litms/utag/voyager-web-feed/utag.js')),
+		margin(),
+
+		// Test sites in our data center
+		testOf('DCGA1', 'Can you reach our primary data center?', loadAsImage('https://www.transip.nl/img/_beyourself/trustpilot-v3.png')),
+		testOf('DCGA2', 'Can you reach our secondary data center?', loadAsImage('https://team.blue/img/cms/index/brands6.png')),
+	]
+;
+
+export default tests;

--- a/src/tests.js
+++ b/src/tests.js
@@ -1,7 +1,6 @@
 import ping from 'web-pingjs';
-import {loadAsImage, loadAsScript, loadAsStyleSheet} from "./loaders";
 
-function dummyTest() {
+export function dummyTest() {
 	const randomSecondDelay = Math.floor(Math.random() * 10) + 1;
 	const result = {
 		success : Math.random() > 0.4,
@@ -9,8 +8,9 @@ function dummyTest() {
 	return async () => new Promise(resolve => setTimeout(() => resolve(result), randomSecondDelay * 1000));
 }
 
-function pingTest(domain) {
-	const DELTA = 0.3;
+const DELTA = 0.3;
+
+export function pingTest(domain) {
 	return async () => {
 		try {
 			const delta = await ping(domain, DELTA);
@@ -35,7 +35,7 @@ function pingTest(domain) {
 	};
 }
 
-function performNetworkRequest(uri, mode = 'cors') {
+export function performNetworkRequest(uri, mode = 'cors') {
 	return async () => {
 		try {
 			const result = await fetch(uri, {
@@ -54,159 +54,3 @@ function performNetworkRequest(uri, mode = 'cors') {
 		}
 	}
 }
-
-async function checkHttp2() {
-	const result = await performNetworkRequest(`https://clients.magnet.me/http_version`)();
-	try {
-		const text = await result.response.text();
-		return {
-			success : text === 'h2',
-			response : text,
-		}
-	} catch (e) {
-		return {
-			success : false,
-			response : e,
-		}
-	}
-}
-
-async function checkTlsProtocol() {
-	const result = await performNetworkRequest(`https://clients.magnet.me/ssl_protocol`)();
-	try {
-		const text = await result.response.text();
-		return {
-			success : text === 'TLSv1.3',
-			response : text,
-		}
-	} catch (e) {
-		return {
-			success : false,
-			response : e,
-		}
-	}
-}
-
-function websockets(secure = false) {
-	const message = `Magnet.me websocket test ${Math.random()}`;
-	return async () => new Promise(((resolve, reject) => {
-		const failed = () => reject({
-			success : false,
-		});
-		const timeout = setTimeout(() => {
-			console.warn('WSS took too long');
-			failed();
-		}, 5000);
-
-		try {
-			const websocket = new WebSocket(`${secure ? 'wss' : 'ws'}://echo.websocket.org/`);
-			let start;
-			websocket.onopen = () => {
-				start = new Date();
-				websocket.send(message);
-			};
-
-			websocket.onmessage = (evt) => {
-				const responseData = evt.data;
-				if (responseData === message) {
-					clearTimeout(timeout);
-					resolve({
-						success : true,
-						response : new Date() - start,
-					});
-				} else {
-					console.log(`Response data was '${responseData}', expected '${message}'.`);
-					failed();
-				}
-			};
-			websocket.onerror = () => {
-				clearTimeout(timeout);
-				failed();
-			}
-		} catch (e) {
-			console.warn(e);
-			clearTimeout(timeout);
-			failed();
-		}
-	}));
-}
-
-function testOf(name, description, test) {
-	return {
-		name,
-		description,
-		test,
-	}
-}
-
-function margin() {
-	return {};
-}
-
-const tests = [
-		margin(),
-
-		testOf('Ping', 'Can you contact Magnet.me at all (domain)?', pingTest('http://magnet.me')),
-		testOf('Ping LB', 'Can you contact our datacenter?', pingTest('http://loadbalancer.magnet.me')),
-		testOf('Ping CDN', 'Can you contact our CDN?', pingTest('http://cdn.magnet.me')),
-		testOf('Ping CDN2', 'Can you contact our alternate CDN?', pingTest('http://cdn2.magnet.me')),
-		testOf('Ping OAuth', 'Can you contact our authentication layer?', performNetworkRequest('https://oauth.magnet.me', 'no-cors')),
-		// No pings for Oauth, since it does not allow remote checks for security reasons
-		margin(),
-
-		testOf('IPv4 - no DNS', 'Does connecting over ipv4 without DNS work?', performNetworkRequest('http://136.144.129.63', 'no-cors')),
-		margin(),
-
-		testOf('IPv4 / HTTP', 'Does connecting over ipv4 work?', performNetworkRequest('http://clients-4.magnet.me')),
-		testOf('IPv4 / HTTPS', 'Does connecting over ipv4 with HTTPS work?', performNetworkRequest('https://clients-4.magnet.me')),
-		margin(),
-
-		// These are allowed to fail if the client network does not support ipv6
-		testOf('IPv6 / HTTP', 'Does connecting over ipv6 work? *', performNetworkRequest('http://clients-6.magnet.me')),
-		testOf('IPv6 / HTTPS', 'Does connecting over ipv6 with HTTPS work? *', performNetworkRequest('https://clients-6.magnet.me')),
-		margin(),
-
-		// The two tests below only work in production
-		testOf('HTTP', 'Can you communicate over HTTP?', loadAsScript(`http://${window.location.host}/demo.js`)),
-		testOf('HTTPS', 'Can you communicate over HTTPS?', loadAsScript(`https://${window.location.host}/demo.js`)),
-		testOf('Secure websockets', 'Can you communicate over secure websockets?', websockets(true)),
-		margin(),
-
-		testOf('Image', 'Can you reach our imaging subsystem?', performNetworkRequest(`https://customerimages.magnet.me/_health`)),
-		testOf('OAuth', 'Can you reach our authentication subsystem?', loadAsScript(`https://oauth.magnet.me/static/js/authentication.js`)),
-		margin(),
-
-		testOf('Web', 'Can you reach our web servers?', loadAsScript(`https://magnet.me/healthcheck`)),
-		testOf('API', 'Can you reach our APIs?', performNetworkRequest(`https://api.magnet.me/healthcheck`)),
-		testOf('Email', 'Can you reach our email servers?', performNetworkRequest(`https://email.magnet.me/_health`, 'no-cors')),
-		testOf('CDN', 'Can you reach our CDN servers?', performNetworkRequest(`https://cdn.magnet.me/images/logo-bigger.png`)),
-		testOf('Fonts', 'Can you load our fonts?', loadAsStyleSheet(`https://magnet.me/fonts/css?family=Source+Sans+Pro:300,400,400i,600,700&display=swap&subset=latin`)),
-		testOf('HTTP2', 'Can you communicate over HTTP2?', checkHttp2),
-		testOf('TLSv1.3', 'Can you communicate using TLSv1.3?', checkTlsProtocol),
-		testOf('Hubspot', 'Can you reach Hubspot?', loadAsScript('https://www.hubspot.com/hs/hsstatic/cos-i18n/static-1.16/bundles/project.js')),
-		testOf('Tentamenrooster', 'Can you reach Tentamenrooster.nl?', loadAsScript('https://tentamenrooster.nl')),
-		margin(),
-
-		// This checks whether Social stuff might be blocked
-		testOf('Facebook', 'Can you contact Facebook.com at all?', pingTest('https://facebook.com')),
-		testOf('LinkedIn', 'Can you contact LinkedIn.com at all?', pingTest('https://www.linkedin.com')),
-		testOf('Twitter', 'Can you contact Twitter.com at all?', pingTest('https://twitter.com')),
-		margin(),
-
-		// Or parts of our Google platform
-		testOf('Google SE', 'Can you contact google.com?', performNetworkRequest('https://www.google.com/', 'no-cors')),
-		testOf('Google Docs', 'Can you contact Google Docs?', performNetworkRequest('https://docs.google.com/forms/d/e/1FAIpQLSf-UqflUetJ64U_h1K8eGjePLArMeBknoaH_tkOZPqq9dizLg/viewform', 'no-cors')),
-		margin(),
-
-		// More internal test of social networks
-		testOf('Facebook CSS', 'Can you reach Facebook Network?', performNetworkRequest('https://facebook.com/security/hsts-pixel.gif')),
-		testOf('LinkedIn JS', 'Can you reach LinkedIn JS?', loadAsScript('https://platform.linkedin.com/litms/utag/voyager-web-feed/utag.js')),
-		margin(),
-
-		// Test sites in our data center
-		testOf('DCGA1', 'Can you reach our primary data center?', loadAsImage('https://www.transip.nl/img/_beyourself/trustpilot-v3.png')),
-		testOf('DCGA2', 'Can you reach our secondary data center?', loadAsImage('https://team.blue/img/cms/index/brands6.png')),
-	]
-;
-
-export default tests;


### PR DESCRIPTION
This adds a `connectivity.magnetme.com/dce` endpoint which can be used by potential customers to validate their access (with internal firewalls and SSL interception for example)

@Magnetme/developers RFR