### PR TITLE
Switch to new websocket implementation

### DIFF
--- a/src/internalTests.js
+++ b/src/internalTests.js
@@ -45,13 +45,14 @@ function websockets(secure = false) {
 		}, 5000);
 
 		try {
-			const websocket = new WebSocket(`${secure ? 'wss' : 'ws'}://echo.websocket.org/`);
+			const websocket = new WebSocket(`${secure ? 'wss' : 'ws'}://echo.websocket.events/`);
 			let start;
 			websocket.onopen = () => {
 				start = new Date();
 				websocket.send(message);
 			};
 
+			let messageCounter = 0;
 			websocket.onmessage = (evt) => {
 				const responseData = evt.data;
 				if (responseData === message) {
@@ -60,6 +61,10 @@ function websockets(secure = false) {
 						success : true,
 						response : new Date() - start,
 					});
+					console.log(`Resolved at messageCounter: ${messageCounter}`);
+				} else if (messageCounter <= 2) {
+					// We expect the message coming back in the first two messages
+					messageCounter++;
 				} else {
 					console.log(`Response data was '${responseData}', expected '${message}'.`);
 					failed();


### PR DESCRIPTION
`echo.websocket.org` no longer works. `echo.websocket.events` is an alternative, but it sends a different first message and correctly responds with the second.
![Screenshot 2021-11-30 at 12 58 01](https://user-images.githubusercontent.com/2778689/144043337-e84f9003-0409-4412-9316-d844989ba191.png)


